### PR TITLE
Fix go version to prevent toolchain download

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/Zeethulhu/plebnet-discord-bot
 
-go 1.24.4
+go 1.24


### PR DESCRIPTION
## Summary
- correct the Go version in go.mod to avoid automatic toolchain download

## Testing
- `GOTOOLCHAIN=local go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6867e79528c883239b32a5dabc8d7993