### PR TITLE
Add game configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ DISCORD_NATS_TOPIC="enshrouded"   # NATS subject to subscribe to
 
 An example YAML configuration file is provided as `config.example.yaml` and can
 be renamed to `config.yaml` or referenced via the `--config` flag when starting
-the bot:
+the bot. A `games` list can also be included where each entry specifies the
+Discord channel, NATS topic, and Steam RSS feed for a game:
 
 ```yaml
 # config.yaml
@@ -24,6 +25,16 @@ discord_token: "TOKEN"
 events_channel: "123456789012345678"
 nats_address: "nats://127.0.0.1:4222"
 nats_topic: "enshrouded-logs"
+
+games:
+  - name: "Enshrouded"
+    discord_channel: "123456789012345678"
+    nats_topic: "enshrouded-logs"
+    steam_rss: "https://store.steampowered.com/feeds/news.xml?appid=1203620"
+  - name: "Valheim"
+    discord_channel: "234567890123456789"
+    nats_topic: "valheim-logs"
+    steam_rss: "https://store.steampowered.com/feeds/news.xml?appid=892970"
 ```
 
 ### Usage

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -9,3 +9,18 @@ events_channel: ""
 nats_address: "nats://127.0.0.1:4222"
 # Topic/subject to subscribe to for server events
 nats_topic: "enshrouded-logs"
+
+# List of games to monitor
+games:
+  - name: "Enshrouded"
+    discord_channel: "123456789012345678"
+    nats_topic: "enshrouded-logs"
+    steam_rss: "https://store.steampowered.com/feeds/news.xml?appid=1203620"
+  - name: "Valheim"
+    discord_channel: "234567890123456789"
+    nats_topic: "valheim-logs"
+    steam_rss: "https://store.steampowered.com/feeds/news.xml?appid=892970"
+  - name: "Palworld"
+    discord_channel: "345678901234567890"
+    nats_topic: "palworld-logs"
+    steam_rss: "https://store.steampowered.com/feeds/news.xml?appid=1623730"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,13 +1,13 @@
 package config
 
 import (
-    "fmt"
-    "os"
-    "strings"
-    "sync"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
 
-    "github.com/joho/godotenv"
-    "gopkg.in/yaml.v3"
+	"github.com/joho/godotenv"
+	"gopkg.in/yaml.v3"
 )
 
 // Default values for optional configuration variables.
@@ -18,114 +18,130 @@ const (
 
 // Options specifies sources of configuration that override defaults.
 type Options struct {
-    ConfigFile    string
-    DiscordToken  string
-    EventsChannel string
-    NatsAddress   string
-    NatsTopic     string
+	ConfigFile    string
+	DiscordToken  string
+	EventsChannel string
+	NatsAddress   string
+	NatsTopic     string
+	Games         []GameConfig
 }
 
 // Config holds the merged configuration values.
 type Config struct {
-    DiscordToken  string
-    EventsChannel string
-    NatsAddress   string
-    NatsTopic     string
+	DiscordToken  string
+	EventsChannel string
+	NatsAddress   string
+	NatsTopic     string
+	Games         []GameConfig
+}
+
+// GameConfig holds configuration for a single game.
+type GameConfig struct {
+	Name           string `yaml:"name"`
+	DiscordChannel string `yaml:"discord_channel"`
+	NatsTopic      string `yaml:"nats_topic"`
+	SteamRSS       string `yaml:"steam_rss"`
 }
 
 var (
-    cfg     Config
-    once    sync.Once
-    loadErr error
+	cfg     Config
+	once    sync.Once
+	loadErr error
 )
 
 // Load reads the environment once and returns the configuration. If required
 // variables are missing it returns an error.
 func Load(opts Options) (Config, error) {
-    once.Do(func() {
-        _ = godotenv.Load()
+	once.Do(func() {
+		_ = godotenv.Load()
 
-        // defaults
-        cfg.NatsAddress = DefaultNatsAddress
-        cfg.NatsTopic = DefaultNatsTopic
+		// defaults
+		cfg.NatsAddress = DefaultNatsAddress
+		cfg.NatsTopic = DefaultNatsTopic
 
-        // config file
-        if opts.ConfigFile != "" {
-            data, err := os.ReadFile(opts.ConfigFile)
-            if err != nil {
-                loadErr = fmt.Errorf("error reading config file: %w", err)
-                return
-            }
-            var fc struct {
-                DiscordToken  string `yaml:"discord_token"`
-                EventsChannel string `yaml:"events_channel"`
-                NatsAddress   string `yaml:"nats_address"`
-                NatsTopic     string `yaml:"nats_topic"`
-            }
-            if err := yaml.Unmarshal(data, &fc); err != nil {
-                loadErr = fmt.Errorf("error parsing config file: %w", err)
-                return
-            }
-            if fc.DiscordToken != "" {
-                cfg.DiscordToken = fc.DiscordToken
-            }
-            if fc.EventsChannel != "" {
-                cfg.EventsChannel = fc.EventsChannel
-            }
-            if fc.NatsAddress != "" {
-                cfg.NatsAddress = fc.NatsAddress
-            }
-            if fc.NatsTopic != "" {
-                cfg.NatsTopic = fc.NatsTopic
-            }
-        }
+		// config file
+		if opts.ConfigFile != "" {
+			data, err := os.ReadFile(opts.ConfigFile)
+			if err != nil {
+				loadErr = fmt.Errorf("error reading config file: %w", err)
+				return
+			}
+			var fc struct {
+				DiscordToken  string       `yaml:"discord_token"`
+				EventsChannel string       `yaml:"events_channel"`
+				NatsAddress   string       `yaml:"nats_address"`
+				NatsTopic     string       `yaml:"nats_topic"`
+				Games         []GameConfig `yaml:"games"`
+			}
+			if err := yaml.Unmarshal(data, &fc); err != nil {
+				loadErr = fmt.Errorf("error parsing config file: %w", err)
+				return
+			}
+			if fc.DiscordToken != "" {
+				cfg.DiscordToken = fc.DiscordToken
+			}
+			if fc.EventsChannel != "" {
+				cfg.EventsChannel = fc.EventsChannel
+			}
+			if fc.NatsAddress != "" {
+				cfg.NatsAddress = fc.NatsAddress
+			}
+			if fc.NatsTopic != "" {
+				cfg.NatsTopic = fc.NatsTopic
+			}
+			if len(fc.Games) > 0 {
+				cfg.Games = fc.Games
+			}
+		}
 
-        // environment variables override file
-        if v := strings.TrimSpace(os.Getenv("DISCORD_TOKEN")); v != "" {
-            cfg.DiscordToken = v
-        }
-        if v := strings.TrimSpace(os.Getenv("DISCORD_EVENTS_CHANNEL")); v != "" {
-            cfg.EventsChannel = v
-        }
-        if v := strings.TrimSpace(os.Getenv("DISCORD_NATS_ADDRESS")); v != "" {
-            cfg.NatsAddress = v
-        }
-        if v := strings.TrimSpace(os.Getenv("DISCORD_NATS_TOPIC")); v != "" {
-            cfg.NatsTopic = v
-        }
+		// environment variables override file
+		if v := strings.TrimSpace(os.Getenv("DISCORD_TOKEN")); v != "" {
+			cfg.DiscordToken = v
+		}
+		if v := strings.TrimSpace(os.Getenv("DISCORD_EVENTS_CHANNEL")); v != "" {
+			cfg.EventsChannel = v
+		}
+		if v := strings.TrimSpace(os.Getenv("DISCORD_NATS_ADDRESS")); v != "" {
+			cfg.NatsAddress = v
+		}
+		if v := strings.TrimSpace(os.Getenv("DISCORD_NATS_TOPIC")); v != "" {
+			cfg.NatsTopic = v
+		}
 
-        // command line flags override env
-        if opts.DiscordToken != "" {
-            cfg.DiscordToken = opts.DiscordToken
-        }
-        if opts.EventsChannel != "" {
-            cfg.EventsChannel = opts.EventsChannel
-        }
-        if opts.NatsAddress != "" {
-            cfg.NatsAddress = opts.NatsAddress
-        }
-        if opts.NatsTopic != "" {
-            cfg.NatsTopic = opts.NatsTopic
-        }
+		// command line flags override env
+		if opts.DiscordToken != "" {
+			cfg.DiscordToken = opts.DiscordToken
+		}
+		if opts.EventsChannel != "" {
+			cfg.EventsChannel = opts.EventsChannel
+		}
+		if opts.NatsAddress != "" {
+			cfg.NatsAddress = opts.NatsAddress
+		}
+		if opts.NatsTopic != "" {
+			cfg.NatsTopic = opts.NatsTopic
+		}
+		if len(opts.Games) > 0 {
+			cfg.Games = opts.Games
+		}
 
-        // ensure defaults for optional values
-        if cfg.NatsAddress == "" {
-            cfg.NatsAddress = DefaultNatsAddress
-        }
-        if cfg.NatsTopic == "" {
-            cfg.NatsTopic = DefaultNatsTopic
-        }
+		// ensure defaults for optional values
+		if cfg.NatsAddress == "" {
+			cfg.NatsAddress = DefaultNatsAddress
+		}
+		if cfg.NatsTopic == "" {
+			cfg.NatsTopic = DefaultNatsTopic
+		}
 
-        if cfg.DiscordToken == "" {
-            loadErr = fmt.Errorf("discord_token is not set")
-            return
-        }
-        if cfg.EventsChannel == "" {
-            loadErr = fmt.Errorf("events_channel is not set")
-            return
-        }
-    })
+		if cfg.DiscordToken == "" {
+			loadErr = fmt.Errorf("discord_token is not set")
+			return
+		}
+		if cfg.EventsChannel == "" {
+			loadErr = fmt.Errorf("events_channel is not set")
+			return
+		}
+	})
 
-    return cfg, loadErr
+	return cfg, loadErr
 }
-

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,9 +1,9 @@
 package config
 
 import (
-    "os"
-    "sync"
-    "testing"
+	"os"
+	"sync"
+	"testing"
 )
 
 func reset() {
@@ -21,56 +21,80 @@ func createEnvFile(t *testing.T, content string) {
 }
 
 func TestDefaultValues(t *testing.T) {
-    os.Clearenv()
-    createEnvFile(t, "")
-    if err := os.Setenv("DISCORD_TOKEN", "token"); err != nil {
-        t.Fatalf("failed to set DISCORD_TOKEN: %v", err)
-    }
-    if err := os.Setenv("DISCORD_EVENTS_CHANNEL", "channel"); err != nil {
-        t.Fatalf("failed to set DISCORD_EVENTS_CHANNEL: %v", err)
-    }
+	os.Clearenv()
+	createEnvFile(t, "")
+	if err := os.Setenv("DISCORD_TOKEN", "token"); err != nil {
+		t.Fatalf("failed to set DISCORD_TOKEN: %v", err)
+	}
+	if err := os.Setenv("DISCORD_EVENTS_CHANNEL", "channel"); err != nil {
+		t.Fatalf("failed to set DISCORD_EVENTS_CHANNEL: %v", err)
+	}
 
-    reset()
-    c, err := Load(Options{})
-    if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
+	reset()
+	c, err := Load(Options{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
-    if c.NatsAddress != DefaultNatsAddress {
-        t.Errorf("expected NatsAddress %q, got %q", DefaultNatsAddress, c.NatsAddress)
-    }
-    if c.NatsTopic != DefaultNatsTopic {
-        t.Errorf("expected NatsTopic %q, got %q", DefaultNatsTopic, c.NatsTopic)
-    }
+	if c.NatsAddress != DefaultNatsAddress {
+		t.Errorf("expected NatsAddress %q, got %q", DefaultNatsAddress, c.NatsAddress)
+	}
+	if c.NatsTopic != DefaultNatsTopic {
+		t.Errorf("expected NatsTopic %q, got %q", DefaultNatsTopic, c.NatsTopic)
+	}
 }
 
 func TestMissingVariables(t *testing.T) {
-    os.Clearenv()
-    createEnvFile(t, "")
+	os.Clearenv()
+	createEnvFile(t, "")
 
-    reset()
-    _, err := Load(Options{})
-    if err == nil {
-        t.Fatal("expected error but got nil")
-    }
+	reset()
+	_, err := Load(Options{})
+	if err == nil {
+		t.Fatal("expected error but got nil")
+	}
 }
 
 func TestConfigFile(t *testing.T) {
-    os.Clearenv()
-    createEnvFile(t, "")
+	os.Clearenv()
+	createEnvFile(t, "")
 
-    content := []byte("discord_token: t\nevents_channel: c\nnats_address: a\nnats_topic: top")
-    if err := os.WriteFile("config.yaml", content, 0644); err != nil {
-        t.Fatalf("failed to create config file: %v", err)
-    }
-    t.Cleanup(func() { _ = os.Remove("config.yaml") })
+	content := []byte("discord_token: t\nevents_channel: c\nnats_address: a\nnats_topic: top")
+	if err := os.WriteFile("config.yaml", content, 0644); err != nil {
+		t.Fatalf("failed to create config file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove("config.yaml") })
 
-    reset()
-    cfg, err := Load(Options{ConfigFile: "config.yaml"})
-    if err != nil {
-        t.Fatalf("unexpected error: %v", err)
-    }
-    if cfg.DiscordToken != "t" || cfg.EventsChannel != "c" || cfg.NatsAddress != "a" || cfg.NatsTopic != "top" {
-        t.Fatalf("config not loaded from file: %+v", cfg)
-    }
+	reset()
+	cfg, err := Load(Options{ConfigFile: "config.yaml"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DiscordToken != "t" || cfg.EventsChannel != "c" || cfg.NatsAddress != "a" || cfg.NatsTopic != "top" {
+		t.Fatalf("config not loaded from file: %+v", cfg)
+	}
+}
+
+func TestGamesFromConfigFile(t *testing.T) {
+	os.Clearenv()
+	createEnvFile(t, "")
+
+	content := []byte("discord_token: t\nevents_channel: c\ngames:\n  - name: g1\n    discord_channel: dc\n    nats_topic: nt\n    steam_rss: sr")
+	if err := os.WriteFile("config.yaml", content, 0644); err != nil {
+		t.Fatalf("failed to create config file: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove("config.yaml") })
+
+	reset()
+	c, err := Load(Options{ConfigFile: "config.yaml"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(c.Games) != 1 {
+		t.Fatalf("expected 1 game, got %d", len(c.Games))
+	}
+	g := c.Games[0]
+	if g.Name != "g1" || g.DiscordChannel != "dc" || g.NatsTopic != "nt" || g.SteamRSS != "sr" {
+		t.Fatalf("unexpected game config: %+v", g)
+	}
 }


### PR DESCRIPTION
## Summary
- add `GameConfig` type and parse a `games` list from config files
- document game-specific options and provide sample entries
- cover YAML game parsing with tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c3eef17388323938c8ff743f0649e