### PR TITLE
Start game handlers from configuration

### DIFF
--- a/internal/discord/server.go
+++ b/internal/discord/server.go
@@ -1,16 +1,16 @@
 package discord
 
 import (
-    "github.com/Zeethulhu/plebnet-discord-bot/internal/config"
+	"github.com/Zeethulhu/plebnet-discord-bot/internal/config"
 )
 
 func StartServer(opts config.Options) {
-        logger.Println("📦 Loading configuration...")
-        cfg, err := config.Load(opts)
-        if err != nil {
-                logger.Fatal(err)
-        }
+	logger.Println("📦 Loading configuration...")
+	cfg, err := config.Load(opts)
+	if err != nil {
+		logger.Fatal(err)
+	}
 
 	logger.Println("🚀 Starting bot...")
-	Start(cfg.DiscordToken, cfg.EventsChannel, cfg.NatsAddress, cfg.NatsTopic)
+	Start(cfg)
 }


### PR DESCRIPTION
## Summary
- iterate over configured games when starting the bot
- register NATS handlers and Steam timers for games with topics or RSS feeds
- pass full configuration object into `discord.Start`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c44338da88323a774c18aa1c248c1