### PR TITLE
feat: add game handler registry

### DIFF
--- a/internal/discord/bot.go
+++ b/internal/discord/bot.go
@@ -7,6 +7,8 @@ import (
 	"syscall"
 
 	"github.com/Zeethulhu/plebnet-discord-bot/internal/config"
+	"github.com/Zeethulhu/plebnet-discord-bot/internal/games"
+	_ "github.com/Zeethulhu/plebnet-discord-bot/internal/games/enshrouded"
 	"github.com/Zeethulhu/plebnet-discord-bot/internal/messagepicker"
 	"github.com/Zeethulhu/plebnet-discord-bot/internal/subscribers"
 	"github.com/Zeethulhu/plebnet-discord-bot/internal/timers"
@@ -62,9 +64,13 @@ func Start(cfg config.Config) {
 		started := false
 
 		if g.NatsTopic != "" {
-			subscribers.NewEnshroudedLoginHandler(channel, g.NatsTopic, manager)
-			logger.Printf("📡 NATS handler started for game '%s' on topic '%s'", g.Name, g.NatsTopic)
-			started = true
+			if handler, ok := games.NewNATSHandler(g.Name, channel, g.NatsTopic, manager); ok {
+				subscribers.Register(handler)
+				logger.Printf("📡 NATS handler started for game '%s' on topic '%s'", g.Name, g.NatsTopic)
+				started = true
+			} else {
+				logger.Printf("⚠️ No NATS handler registered for game '%s'", g.Name)
+			}
 		} else {
 			logger.Printf("⚠️ Game '%s' missing NATS topic; NATS handler not started", g.Name)
 		}

--- a/internal/games/games.go
+++ b/internal/games/games.go
@@ -1,0 +1,35 @@
+package games
+
+import (
+	"github.com/Zeethulhu/plebnet-discord-bot/internal/messagepicker"
+	"github.com/bwmarrin/discordgo"
+	"github.com/nats-io/nats.go"
+)
+
+// GameNATSHandler defines the behavior of a game-specific NATS message handler.
+type GameNATSHandler interface {
+	// Subject returns the NATS subject this handler subscribes to.
+	Subject() string
+	// Handle processes a NATS message using the provided Discord session.
+	Handle(msg *nats.Msg, s *discordgo.Session)
+}
+
+// HandlerFactory creates a NATS handler for a game.
+type HandlerFactory func(channelID, subject string, manager *messagepicker.MessageManager) GameNATSHandler
+
+var natsHandlers = map[string]HandlerFactory{}
+
+// RegisterNATSHandler registers a factory for the given game name.
+func RegisterNATSHandler(name string, f HandlerFactory) {
+	natsHandlers[name] = f
+}
+
+// NewNATSHandler instantiates a handler for the specified game.
+// The boolean return indicates whether a factory was registered for that game.
+func NewNATSHandler(name, channelID, subject string, manager *messagepicker.MessageManager) (GameNATSHandler, bool) {
+	f, ok := natsHandlers[name]
+	if !ok {
+		return nil, false
+	}
+	return f(channelID, subject, manager), true
+}

--- a/internal/subscribers/registry.go
+++ b/internal/subscribers/registry.go
@@ -1,26 +1,15 @@
 package subscribers
 
-import (
-	"github.com/bwmarrin/discordgo"
-	"github.com/nats-io/nats.go"
-)
+import "github.com/Zeethulhu/plebnet-discord-bot/internal/games"
 
-// Handler represents a subscription handler for a NATS subject.
-type Handler interface {
-	// Subject returns the NATS subject this handler subscribes to.
-	Subject() string
-	// Handle processes a NATS message.
-	Handle(msg *nats.Msg, s *discordgo.Session)
-}
-
-var registry []Handler
+var registry []games.GameNATSHandler
 
 // Register adds a handler to the registry.
-func Register(h Handler) {
+func Register(h games.GameNATSHandler) {
 	registry = append(registry, h)
 }
 
 // All returns all registered handlers.
-func All() []Handler {
+func All() []games.GameNATSHandler {
 	return registry
 }


### PR DESCRIPTION
## Summary
- introduce `GameNATSHandler` interface and registry for game-specific handlers
- move Enshrouded login handler under new games package and register via `init`
- allow Discord bot to dynamically register game handlers

## Testing
- `go test -mod=vendor ./...` *(fails: inconsistent vendoring)*

------
https://chatgpt.com/codex/tasks/task_e_689c497876848323be25fe88a908bd0b