### PR TITLE
feat: add reusable Steam news timer

### DIFF
--- a/internal/discord/bot.go
+++ b/internal/discord/bot.go
@@ -76,7 +76,7 @@ func Start(cfg config.Config) {
 		}
 
 		if g.SteamRSS != "" {
-			if _, err := timers.NewEnshroudedNewsTimer(channel, "steam_news.db"); err != nil {
+			if _, err := timers.NewSteamNewsTimer(channel, g.SteamRSS, "steam_news.db"); err != nil {
 				logger.Printf("❌ Failed to start Steam news timer for '%s': %v", g.Name, err)
 			} else {
 				timersStarted = true

--- a/internal/games/enshrouded/news.go
+++ b/internal/games/enshrouded/news.go
@@ -1,0 +1,10 @@
+package enshrouded
+
+import "github.com/Zeethulhu/plebnet-discord-bot/internal/timers"
+
+const steamNewsFeed = "https://store.steampowered.com/feeds/news/app/1203620/"
+
+// NewNewsTimer creates a SteamNewsTimer for Enshrouded.
+func NewNewsTimer(channelID, dbPath string) (*timers.SteamNewsTimer, error) {
+	return timers.NewSteamNewsTimer(channelID, steamNewsFeed, dbPath)
+}


### PR DESCRIPTION
## Summary
- add generic SteamNewsTimer for parsing any Steam RSS feed
- expose Enshrouded helper that wraps SteamNewsTimer
- register Steam news timer for games configured with SteamRSS

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689c53e5956483238df7be6f0832236b