### PR TITLE
Make global events channel optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ deployments, but for local use you can copy `.env.example` to `.env`:
 
 ```
 DISCORD_TOKEN="..."               # Discord bot token
-DISCORD_EVENTS_CHANNEL="..."      # Channel ID for server event messages
+DISCORD_EVENTS_CHANNEL="..."      # (optional) default channel ID for server event messages
 DISCORD_NATS_ADDRESS="nats://127.0.0.1:4222"  # NATS server address
 DISCORD_NATS_TOPIC="enshrouded"   # NATS subject to subscribe to
 ```
@@ -22,6 +22,7 @@ Discord channel, NATS topic, and Steam RSS feed for a game:
 ```yaml
 # config.yaml
 discord_token: "TOKEN"
+# Optional default channel. Each game entry can override discord_channel.
 events_channel: "123456789012345678"
 nats_address: "nats://127.0.0.1:4222"
 nats_topic: "enshrouded-logs"

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,8 +2,9 @@
 # Copy this file to config.yaml and fill in your values.
 
 discord_token: ""
-# Discord channel ID for sending messages
+# Optional default Discord channel ID for sending messages
 # e.g. "123456789012345678"
+# If not set, each game entry must specify its own discord_channel
 events_channel: ""
 # Address of the NATS server
 nats_address: "nats://127.0.0.1:4222"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -137,10 +137,6 @@ func Load(opts Options) (Config, error) {
 			loadErr = fmt.Errorf("discord_token is not set")
 			return
 		}
-		if cfg.EventsChannel == "" {
-			loadErr = fmt.Errorf("events_channel is not set")
-			return
-		}
 	})
 
 	return cfg, loadErr

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,9 +26,6 @@ func TestDefaultValues(t *testing.T) {
 	if err := os.Setenv("DISCORD_TOKEN", "token"); err != nil {
 		t.Fatalf("failed to set DISCORD_TOKEN: %v", err)
 	}
-	if err := os.Setenv("DISCORD_EVENTS_CHANNEL", "channel"); err != nil {
-		t.Fatalf("failed to set DISCORD_EVENTS_CHANNEL: %v", err)
-	}
 
 	reset()
 	c, err := Load(Options{})
@@ -41,6 +38,9 @@ func TestDefaultValues(t *testing.T) {
 	}
 	if c.NatsTopic != DefaultNatsTopic {
 		t.Errorf("expected NatsTopic %q, got %q", DefaultNatsTopic, c.NatsTopic)
+	}
+	if c.EventsChannel != "" {
+		t.Errorf("expected EventsChannel to be empty, got %q", c.EventsChannel)
 	}
 }
 
@@ -59,7 +59,7 @@ func TestConfigFile(t *testing.T) {
 	os.Clearenv()
 	createEnvFile(t, "")
 
-	content := []byte("discord_token: t\nevents_channel: c\nnats_address: a\nnats_topic: top")
+	content := []byte("discord_token: t\nnats_address: a\nnats_topic: top")
 	if err := os.WriteFile("config.yaml", content, 0644); err != nil {
 		t.Fatalf("failed to create config file: %v", err)
 	}
@@ -70,7 +70,7 @@ func TestConfigFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.DiscordToken != "t" || cfg.EventsChannel != "c" || cfg.NatsAddress != "a" || cfg.NatsTopic != "top" {
+	if cfg.DiscordToken != "t" || cfg.NatsAddress != "a" || cfg.NatsTopic != "top" || cfg.EventsChannel != "" {
 		t.Fatalf("config not loaded from file: %+v", cfg)
 	}
 }
@@ -79,7 +79,7 @@ func TestGamesFromConfigFile(t *testing.T) {
 	os.Clearenv()
 	createEnvFile(t, "")
 
-	content := []byte("discord_token: t\nevents_channel: c\ngames:\n  - name: g1\n    discord_channel: dc\n    nats_topic: nt\n    steam_rss: sr")
+	content := []byte("discord_token: t\ngames:\n  - name: g1\n    discord_channel: dc\n    nats_topic: nt\n    steam_rss: sr")
 	if err := os.WriteFile("config.yaml", content, 0644); err != nil {
 		t.Fatalf("failed to create config file: %v", err)
 	}
@@ -89,6 +89,9 @@ func TestGamesFromConfigFile(t *testing.T) {
 	c, err := Load(Options{ConfigFile: "config.yaml"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if c.EventsChannel != "" {
+		t.Fatalf("expected EventsChannel to be empty, got %q", c.EventsChannel)
 	}
 	if len(c.Games) != 1 {
 		t.Fatalf("expected 1 game, got %d", len(c.Games))

--- a/internal/discord/bot.go
+++ b/internal/discord/bot.go
@@ -54,7 +54,9 @@ func Start(cfg config.Config) {
 	for _, g := range cfg.Games {
 		channel := g.DiscordChannel
 		if channel == "" {
-			channel = cfg.EventsChannel
+			if cfg.EventsChannel != "" {
+				channel = cfg.EventsChannel
+			}
 		}
 		if channel == "" {
 			logger.Printf("⚠️ Skipping game '%s': no Discord channel configured", g.Name)


### PR DESCRIPTION
## Summary
- Allow configuration without a global `events_channel`
- Let Discord bot rely on per-game channels when no default is provided
- Document that `events_channel` is optional

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cb4273f908323885e0a3ac6d044f5