### PR TITLE
Add per-game Steam news DB and timer cleanup

### DIFF
--- a/internal/discord/bot.go
+++ b/internal/discord/bot.go
@@ -2,8 +2,10 @@ package discord
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/Zeethulhu/plebnet-discord-bot/internal/config"
@@ -78,7 +80,8 @@ func Start(cfg config.Config) {
 		}
 
 		if g.SteamRSS != "" {
-			if _, err := timers.NewSteamNewsTimer(channel, g.SteamRSS, "steam_news.db"); err != nil {
+			dbPath := fmt.Sprintf("steam_news_%s.db", strings.ToLower(g.Name))
+			if _, err := timers.NewSteamNewsTimer(channel, g.SteamRSS, dbPath); err != nil {
 				logger.Printf("❌ Failed to start Steam news timer for '%s': %v", g.Name, err)
 			} else {
 				timersStarted = true

--- a/internal/timers/registry.go
+++ b/internal/timers/registry.go
@@ -12,6 +12,7 @@ type Task interface {
 	Name() string
 	Interval() time.Duration
 	Run(ctx context.Context, s *discordgo.Session)
+	Close() error
 }
 
 var registry []Task

--- a/internal/timers/scheduler.go
+++ b/internal/timers/scheduler.go
@@ -19,6 +19,9 @@ func Start(ctx context.Context, s *discordgo.Session) {
 				select {
 				case <-ctx.Done():
 					logger.Printf("🛑 Timer '%s' stopped", task.Name())
+					if err := task.Close(); err != nil {
+						logger.Printf("❌ Error closing timer '%s': %v", task.Name(), err)
+					}
 					return
 				case <-ticker.C:
 					task.Run(ctx, s)

--- a/internal/timers/steam_news.go
+++ b/internal/timers/steam_news.go
@@ -64,3 +64,8 @@ func (t *SteamNewsTimer) Run(ctx context.Context, s *discordgo.Session) {
 		}
 	}
 }
+
+// Close shuts down the underlying database.
+func (t *SteamNewsTimer) Close() error {
+	return t.db.Close()
+}


### PR DESCRIPTION
## Summary
- derive a unique Steam news database file for each configured game
- allow Steam news timer to close its database and make scheduler call Close on shutdown

## Testing
- `go test ./internal/...`


------
https://chatgpt.com/codex/tasks/task_e_689cbbf3faf883238203be6109fd2bbe