### PR TITLE
Skip missing message templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ games:
     steam_rss: "https://store.steampowered.com/feeds/news.xml?appid=892970"
 ```
 
+Message templates for each game can be placed under `internal/config/messages/<game>.yaml`,
+but they are optional. If a template file is missing or unreadable the bot will
+fall back to basic join/leave notifications.
+
 ### Usage
 
 Run the bot using Go directly or with a built binary. Command line flags override

--- a/internal/messagepicker/message_manager.go
+++ b/internal/messagepicker/message_manager.go
@@ -9,8 +9,11 @@ import (
 	"time"
 
 	"github.com/Zeethulhu/plebnet-discord-bot/internal/config"
+	"github.com/Zeethulhu/plebnet-discord-bot/internal/utils"
 	"gopkg.in/yaml.v3"
 )
+
+var logger = utils.NewLogger("Messages")
 
 // MessagesByCategory holds categorized message lists from YAML
 type MessagesByCategory map[string][]string
@@ -36,11 +39,13 @@ func NewManager(dir string, games []config.GameConfig, recentSize int) (*Manager
 		path := filepath.Join(dir, filename)
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return nil, fmt.Errorf("reading messages for %s: %w", g.Name, err)
+			logger.Printf("⚠️ skipping messages for %s: %v", g.Name, err)
+			continue
 		}
 		var messages MessagesByCategory
 		if err := yaml.Unmarshal(data, &messages); err != nil {
-			return nil, fmt.Errorf("parsing messages for %s: %w", g.Name, err)
+			logger.Printf("⚠️ skipping messages for %s: %v", g.Name, err)
+			continue
 		}
 		m.games[g.Name] = &GameManager{
 			messages:   messages,


### PR DESCRIPTION
## Summary
- Ignore unreadable message template files with a warning
- Fall back to basic join/leave notifications when Enshrouded templates are missing
- Note that per-game message templates are optional

## Testing
- `go test ./internal/messagepicker`

------
https://chatgpt.com/codex/tasks/task_e_689cbe3accd08323a5df7254cc5716dc