### PR TITLE
refactor: single-line unrecognized Enshrouded message

### DIFF
--- a/internal/games/enshrouded/nats.go
+++ b/internal/games/enshrouded/nats.go
@@ -85,7 +85,7 @@ func (h *LoginHandler) Handle(msg *nats.Msg, discord *discordgo.Session) {
 			logger.Printf("❌ Failed to send message: %v", err)
 		}
 	} else {
-		_, err := discord.ChannelMessageSend(h.ChannelID, fmt.Sprintf("⚠️ Unrecognized player event for @%s at %s", event.Player, tStr))
+		_, err := discord.ChannelMessageSend(h.ChannelID, "⚠️ Unrecognized player event for @"+event.Player+" at "+tStr)
 		if err != nil {
 			logger.Printf("❌ Failed to send message: %v", err)
 		}


### PR DESCRIPTION
## Summary
- collapse multi-line fmt.Sprintf call in Enshrouded NATS handler

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689cc077a72483239207f5f7efe5a973