### PR TITLE
Default games to fallback NATS topic

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,7 +8,8 @@ discord_token: ""
 events_channel: ""
 # Address of the NATS server
 nats_address: "nats://127.0.0.1:4222"
-# Topic/subject to subscribe to for server events
+# Topic/subject to subscribe to for server events. Acts as a fallback for
+# games that do not specify their own nats_topic.
 nats_topic: "enshrouded-logs"
 
 # List of games to monitor
@@ -23,5 +24,5 @@ games:
     steam_rss: "https://store.steampowered.com/feeds/news.xml?appid=892970"
   - name: "Palworld"
     discord_channel: "345678901234567890"
-    nats_topic: "palworld-logs"
+    # nats_topic omitted: will fall back to the root nats_topic
     steam_rss: "https://store.steampowered.com/feeds/news.xml?appid=1623730"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,16 +31,19 @@ type Config struct {
 	DiscordToken  string
 	EventsChannel string
 	NatsAddress   string
-	NatsTopic     string
-	Games         []GameConfig
+	// NatsTopic is the default NATS subject used when a game does not
+	// specify its own nats_topic.
+	NatsTopic string
+	Games     []GameConfig
 }
 
 // GameConfig holds configuration for a single game.
 type GameConfig struct {
 	Name           string `yaml:"name"`
 	DiscordChannel string `yaml:"discord_channel"`
-	NatsTopic      string `yaml:"nats_topic"`
-	SteamRSS       string `yaml:"steam_rss"`
+	// NatsTopic overrides the root NatsTopic for this specific game.
+	NatsTopic string `yaml:"nats_topic"`
+	SteamRSS  string `yaml:"steam_rss"`
 }
 
 var (

--- a/internal/discord/bot.go
+++ b/internal/discord/bot.go
@@ -67,10 +67,15 @@ func Start(cfg config.Config) {
 
 		started := false
 
-		if g.NatsTopic != "" {
-			if handler, ok := games.NewNATSHandler(g.Name, channel, g.NatsTopic, manager); ok {
+		topic := g.NatsTopic
+		if topic == "" {
+			topic = cfg.NatsTopic // fallback to root config topic
+		}
+
+		if topic != "" {
+			if handler, ok := games.NewNATSHandler(g.Name, channel, topic, manager); ok {
 				subscribers.Register(handler)
-				logger.Printf("📡 NATS handler started for game '%s' on topic '%s'", g.Name, g.NatsTopic)
+				logger.Printf("📡 NATS handler started for game '%s' on topic '%s'", g.Name, topic)
 				started = true
 			} else {
 				logger.Printf("⚠️ No NATS handler registered for game '%s'", g.Name)


### PR DESCRIPTION
## Summary
- default game's NATS topic to root fallback when missing
- document global `nats_topic` as the fallback in config and example

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689da96df1bc8323a86778ea881dd16b