### PR TITLE
Close DB on SteamNewsTimer init error

### DIFF
--- a/internal/timers/steam_news.go
+++ b/internal/timers/steam_news.go
@@ -25,6 +25,7 @@ func NewSteamNewsTimer(channelID, feedURL, dbPath string) (*SteamNewsTimer, erro
 		return nil, err
 	}
 	if _, err := db.Exec(`CREATE TABLE IF NOT EXISTS posts (guid TEXT PRIMARY KEY)`); err != nil {
+		db.Close()
 		return nil, err
 	}
 	t := &SteamNewsTimer{ChannelID: channelID, feedURL: feedURL, db: db, parser: gofeed.NewParser()}


### PR DESCRIPTION
## Summary
- ensure database is closed if SteamNewsTimer table creation fails

## Testing
- `go test ./...` *(fails: command hung, no output)*

------
https://chatgpt.com/codex/tasks/task_e_689dd9da474483239fcd3344cefe95bb