### PR TITLE
Log startup before server launch

### DIFF
--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -26,8 +26,8 @@ func main() {
         NatsTopic:     *natsTopic,
     }
 
-    discord.StartServer(opts)
     logger.Println(getStartupMessage())
+    discord.StartServer(opts)
 }
 
 func getStartupMessage() string {


### PR DESCRIPTION
## Summary
- log the startup message prior to initializing the Discord server

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689dd9d768b8832394d7a544058b2468