### PR TITLE
Add verbose logging mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ both environment variables and the config file.
 ```bash
 go run ./cmd/bot --config config.yaml
 
+# Enable verbose logging
+go run ./cmd/bot --config config.yaml --verbose
+
 # Override specific options
 go run ./cmd/bot --token "$DISCORD_TOKEN" --channel "$DISCORD_CHANNEL"
 ```

--- a/cmd/bot/main.go
+++ b/cmd/bot/main.go
@@ -1,33 +1,36 @@
 package main
 
 import (
-    "flag"
+	"flag"
 
-    "github.com/Zeethulhu/plebnet-discord-bot/internal/config"
-    "github.com/Zeethulhu/plebnet-discord-bot/internal/discord"
-    "github.com/Zeethulhu/plebnet-discord-bot/internal/utils"
+	"github.com/Zeethulhu/plebnet-discord-bot/internal/config"
+	"github.com/Zeethulhu/plebnet-discord-bot/internal/discord"
+	"github.com/Zeethulhu/plebnet-discord-bot/internal/utils"
 )
 
 var logger = utils.NewLogger("Main")
 
 func main() {
-    cfgFile := flag.String("config", "", "path to config file")
-    token := flag.String("token", "", "discord bot token")
-    channel := flag.String("channel", "", "discord events channel")
-    natsAddr := flag.String("nats", "", "nats server address")
-    natsTopic := flag.String("topic", "", "nats subject")
-    flag.Parse()
+	cfgFile := flag.String("config", "", "path to config file")
+	token := flag.String("token", "", "discord bot token")
+	channel := flag.String("channel", "", "discord events channel")
+	natsAddr := flag.String("nats", "", "nats server address")
+	natsTopic := flag.String("topic", "", "nats subject")
+	verbose := flag.Bool("verbose", false, "enable verbose logging")
+	flag.Parse()
 
-    opts := config.Options{
-        ConfigFile:    *cfgFile,
-        DiscordToken:  *token,
-        EventsChannel: *channel,
-        NatsAddress:   *natsAddr,
-        NatsTopic:     *natsTopic,
-    }
+	utils.SetVerbose(*verbose)
 
-    logger.Println(getStartupMessage())
-    discord.StartServer(opts)
+	opts := config.Options{
+		ConfigFile:    *cfgFile,
+		DiscordToken:  *token,
+		EventsChannel: *channel,
+		NatsAddress:   *natsAddr,
+		NatsTopic:     *natsTopic,
+	}
+
+	logger.Println(getStartupMessage())
+	discord.StartServer(opts)
 }
 
 func getStartupMessage() string {

--- a/internal/discord/commands/logger.go
+++ b/internal/discord/commands/logger.go
@@ -1,8 +1,5 @@
 package commands
 
-import (
-	"log"
-	"os"
-)
+import "github.com/Zeethulhu/plebnet-discord-bot/internal/utils"
 
-var logger = log.New(os.Stdout, "[Discord] ", log.LstdFlags)
+var logger = utils.NewLogger("Discord")

--- a/internal/discord/message.go
+++ b/internal/discord/message.go
@@ -19,6 +19,8 @@ func MessageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 		return
 	}
 
+	logger.Printf("💬 Received Discord message from %s: %s", m.Author.Username, m.Content)
+
 	// Parse command and arguments
 	content := strings.TrimPrefix(m.Content, prefix)
 	parts := utils.ParseArgs(content)

--- a/internal/games/enshrouded/nats.go
+++ b/internal/games/enshrouded/nats.go
@@ -44,7 +44,7 @@ func (h *LoginHandler) Subject() string { return h.SubjectName }
 
 func (h *LoginHandler) Handle(msg *nats.Msg, discord *discordgo.Session) {
 	var event ServerEvent
-	logger.Println("Received Enshrouded event")
+	logger.Printf("📨 Received Enshrouded NATS message: %s", string(msg.Data))
 	if err := json.Unmarshal(msg.Data, &event); err != nil {
 		logger.Printf("❌ Failed to parse event: %v", err)
 		return

--- a/internal/subscribers/nats.go
+++ b/internal/subscribers/nats.go
@@ -10,6 +10,7 @@ func StartListeners(nc *nats.Conn, discord *discordgo.Session) {
 	for _, h := range All() {
 		handler := h
 		_, err := nc.Subscribe(handler.Subject(), func(msg *nats.Msg) {
+			logger.Printf("📨 Received NATS message on '%s': %s", msg.Subject, string(msg.Data))
 			handler.Handle(msg, discord)
 		})
 		if err != nil {

--- a/internal/utils/log_contructor.go
+++ b/internal/utils/log_contructor.go
@@ -1,10 +1,30 @@
 package utils
 
 import (
+	"io"
 	"log"
 	"os"
 )
 
+var verbose bool
+
+// SetVerbose enables or disables verbose logging for all loggers created via
+// this package.
+func SetVerbose(v bool) {
+	verbose = v
+}
+
+type verboseWriter struct{}
+
+func (verboseWriter) Write(p []byte) (int, error) {
+	if verbose {
+		return os.Stdout.Write(p)
+	}
+	return io.Discard.Write(p)
+}
+
+// NewLogger returns a logger that writes output only when verbose mode is
+// enabled via SetVerbose.
 func NewLogger(pkg string) *log.Logger {
-	return log.New(os.Stdout, "["+pkg+"] ", log.LstdFlags)
+	return log.New(verboseWriter{}, "["+pkg+"] ", log.LstdFlags)
 }


### PR DESCRIPTION
## Summary
- add global verbose logging flag and supporting utilities
- wire verbose flag into bot CLI and command logger
- document verbose usage in README
- log incoming NATS and Discord messages at ingestion points

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_689e0f3a5d5c8323ae3e1746006115f3